### PR TITLE
Update target frameworks to .NET 9.0

### DIFF
--- a/samples/ConsoleDemo/ConsoleDemo.csproj
+++ b/samples/ConsoleDemo/ConsoleDemo.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-ConsoleDemo-31BFC000-2F0A-4F5C-884C-945DDE2E4123</UserSecretsId>

--- a/src/ARSoftware.Cfdi.DescargaMasiva/ARSoftware.Cfdi.DescargaMasiva.csproj
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/ARSoftware.Cfdi.DescargaMasiva.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>net9.0</TargetFrameworks>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Version>3.0.0</Version>


### PR DESCRIPTION
Update target frameworks to .NET 9.0

Updated `ConsoleDemo.csproj` to target .NET 9.0, enhancing project capabilities.
Modified `ARSoftware.Cfdi.DescargaMasiva.csproj` to exclusively target .NET 9.0, removing support for previous frameworks.