### PR TITLE
Actualiza binary security token id

### DIFF
--- a/src/ARSoftware.Cfdi.DescargaMasiva/Helpers/SoapRequestHelper.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Helpers/SoapRequestHelper.cs
@@ -14,7 +14,7 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Helpers
 
         public static string ToBinarySecurityTokenId(this Guid uuid)
         {
-            return $"uuid-{uuid}-1";
+            return $"uuid-{uuid}-4";
         }
 
         public static string ToSoapStartDateString(this DateTime date)


### PR DESCRIPTION
Update token format in ToBinarySecurityTokenId method

Modified the `ToBinarySecurityTokenId` method in `SoapRequestHelper.cs` to change the version number in the returned string from `-1` to `-4`. This change reflects an update in the token format.

#### PR Classification
API change.

#### PR Summary
The `ToBinarySecurityTokenId` method in the `SoapRequestHelper.cs` file has been updated to modify the version number in the returned string from `-1` to `-4`. 
- `SoapRequestHelper.cs`: Updated the version number in the `ToBinarySecurityTokenId` method's return string from `-1` to `-4`.
