### PR TITLE
Actualiza valores en TipoSolicitud

### DIFF
--- a/src/ARSoftware.Cfdi.DescargaMasiva/Enumerations/TipoSolicitud.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Enumerations/TipoSolicitud.cs
@@ -5,19 +5,19 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Enumerations
     /// <summary>
     ///     Define el tipo de descarga. Valor utilizado en el atributo TipoSolicitud de la peticion de solicitud.
     /// </summary>
-    public sealed class TipoSolicitud : SmartEnum<TipoSolicitud>
+    public sealed class TipoSolicitud : SmartEnum<TipoSolicitud, string>
     {
         /// <summary>
-        ///     0 = CFDI
+        ///     Metadata
         /// </summary>
-        public static readonly TipoSolicitud Cfdi = new TipoSolicitud("CFDI", 0);
+        public static readonly TipoSolicitud Metadata = new("Metadata", "Metadata");
 
         /// <summary>
-        ///     1 = Metadata
+        ///     CFDI
         /// </summary>
-        public static readonly TipoSolicitud Metadata = new TipoSolicitud("Metadata", 1);
+        public static readonly TipoSolicitud Cfdi = new("CFDI", "CFDI");
 
-        private TipoSolicitud(string name, int value) : base(name, value)
+        private TipoSolicitud(string name, string value) : base(name, value)
         {
         }
     }


### PR DESCRIPTION
Refactor TipoSolicitud to use string values

Updated TipoSolicitud class to inherit from SmartEnum<TipoSolicitud, string>.
Reordered static fields Cfdi and Metadata to use string values instead of integers.
Modified constructor to accept a string value, aligning with the new design.