### PR TITLE
Enable nullable in project

### DIFF
--- a/samples/ConsoleDemo/Program.cs
+++ b/samples/ConsoleDemo/Program.cs
@@ -35,7 +35,7 @@ logger.LogInformation("Buscando el servicio de autenticacion en el contenedor de
 IAutenticacionService autenticacionService = host.Services.GetRequiredService<IAutenticacionService>();
 
 logger.LogInformation("Creando solicitud de autenticacion.");
-AutenticacionRequest? autenticacionRequest = AutenticacionRequest.CreateInstance();
+AutenticacionRequest autenticacionRequest = AutenticacionRequest.CreateInstance();
 
 logger.LogInformation("Enviando solicitud de autenticacion.");
 AutenticacionResult autenticacionResult =
@@ -73,7 +73,7 @@ SolicitudDescargaRecibidosRequest solicitudPorRangoFecha = new()
 };
 
 logger.LogInformation("Enviando solicitud de solicitud de descarga.");
-SolicitudDescargaRecibidosResult? solicitudResult =
+SolicitudDescargaRecibidosResult solicitudResult =
     await solicitudService.SendSoapRequestAsync(solicitudPorRangoFecha, certificadoSat, cancellationToken);
 
 if (string.IsNullOrEmpty(solicitudResult.IdSolicitud))
@@ -90,7 +90,7 @@ logger.LogInformation("Buscando el servicio de verificacion en el contenedor de 
 IVerificacionService verificaSolicitudService = host.Services.GetRequiredService<IVerificacionService>();
 
 logger.LogInformation("Creando solicitud de verificacion.");
-VerificacionRequest? verificacionRequest =
+VerificacionRequest verificacionRequest =
     VerificacionRequest.CreateInstance(solicitudResult.IdSolicitud, rfcSolicitante, autenticacionResult.AccessToken);
 
 logger.LogInformation("Enviando solicitud de verificacion.");
@@ -127,10 +127,10 @@ foreach (string idsPaquete in verificacionResult.PackageIds)
 logger.LogInformation("Buscando el servicio de verificacion en el contenedor de servicios (Dependency Injection).");
 IDescargaService descargarSolicitudService = host.Services.GetRequiredService<IDescargaService>();
 
-foreach (string? idsPaquete in verificacionResult.PackageIds)
+foreach (string idsPaquete in verificacionResult.PackageIds)
 {
     logger.LogInformation("Creando solicitud de descarga.");
-    DescargaRequest? descargaRequest = DescargaRequest.CreateInstace(idsPaquete, rfcSolicitante, autenticacionResult.AccessToken);
+    DescargaRequest descargaRequest = DescargaRequest.CreateInstace(idsPaquete, rfcSolicitante, autenticacionResult.AccessToken);
 
     logger.LogInformation("Enviando solicitud de descarga.");
     DescargaResult descargaResult = await descargarSolicitudService.SendSoapRequestAsync(descargaRequest,

--- a/src/ARSoftware.Cfdi.DescargaMasiva/ARSoftware.Cfdi.DescargaMasiva.csproj
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/ARSoftware.Cfdi.DescargaMasiva.csproj
@@ -20,6 +20,7 @@
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<IncludeSymbols>True</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/ARSoftware.Cfdi.DescargaMasiva/ARSoftware.Cfdi.DescargaMasiva.csproj
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/ARSoftware.Cfdi.DescargaMasiva.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net9.0</TargetFrameworks>
+		<Nullable>enable</Nullable>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Version>3.0.0</Version>
@@ -20,7 +21,6 @@
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<IncludeSymbols>True</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-		<Nullable>enable</Nullable>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Helpers/SignedXmlHelper.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Helpers/SignedXmlHelper.cs
@@ -85,13 +85,13 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Helpers
             {
             }
 
-            public override XmlElement GetIdElement(XmlDocument doc, string id)
+            public override XmlElement? GetIdElement(XmlDocument? doc, string id)
             {
                 if (doc is null)
                     throw new ArgumentNullException(nameof(doc), "The XmlDocument cannot be null.");
 
                 // check to see if it's a standard ID reference
-                XmlElement idElem = base.GetIdElement(doc, id);
+                XmlElement? idElem = base.GetIdElement(doc, id);
 
                 if (idElem is null)
                 {

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaFolioRequest.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaFolioRequest.cs
@@ -13,7 +13,7 @@
         /// <summary>
         ///     Contiene el RFC del que está realizando la solicitud de descarga.
         /// </summary>
-        public string RfcSolicitante { get; init; }
+        public string RfcSolicitante { get; init; } = string.Empty;
 
         /// <summary>
         ///     Folio Fiscal con formato:

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaRecibidosRequest.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaRecibidosRequest.cs
@@ -35,7 +35,7 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
         ///     Contiene el RFC del emisor del cual se quiere consultar los CFDIs.
         ///     Parámetro opcional.
         /// </summary>
-        public string RfcEmisor { get; init; }
+        public string RfcEmisor { get; init; } = string.Empty;
 
         /// <summary>
         ///     El RFC Solicitante corresponde al contribuyente que está realizando la solicitud de descarga.

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Services/AutenticacionService.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Services/AutenticacionService.cs
@@ -115,14 +115,14 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Services
             XmlDocument xmlDocument = new();
             xmlDocument.LoadXml(soapRequestResult.ResponseContent);
 
-            XmlNode autenticaResultElement = xmlDocument.GetElementsByTagName("AutenticaResult")[0];
+            XmlNode? autenticaResultElement = xmlDocument.GetElementsByTagName("AutenticaResult")[0];
             if (autenticaResultElement != null)
             {
                 AccessToken accessToken = AccessToken.CreateInstance(autenticaResultElement.InnerXml);
                 return AutenticacionResult.CreateSuccess(accessToken, soapRequestResult.HttpStatusCode, soapRequestResult.ResponseContent);
             }
 
-            XmlNode errorElement = xmlDocument.GetElementsByTagName("s:Fault")[0];
+            XmlNode? errorElement = xmlDocument.GetElementsByTagName("s:Fault")[0];
             if (errorElement is null)
             {
                 throw new InvalidResponseContentException("Elements AutenticaResult and s:Fault are missing in response.",

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Services/DescargaService.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Services/DescargaService.cs
@@ -81,7 +81,7 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Services
             XmlDocument xmlDocument = new();
             xmlDocument.LoadXml(soapRequestResult.ResponseContent);
 
-            XmlNode element = xmlDocument.GetElementsByTagName("h:respuesta")[0];
+            XmlNode? element = xmlDocument.GetElementsByTagName("h:respuesta")[0];
             if (element is null)
                 throw new InvalidResponseContentException("Element h:respuesta is missing in response.", soapRequestResult.ResponseContent);
 

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Services/SolicitudDescargaEmitidosService.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Services/SolicitudDescargaEmitidosService.cs
@@ -131,7 +131,7 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Services
             XmlDocument xmlDocument = new();
             xmlDocument.LoadXml(soapRequestResult.ResponseContent);
 
-            XmlNode element = xmlDocument.GetElementsByTagName("SolicitaDescargaEmitidosResult")[0];
+            XmlNode? element = xmlDocument.GetElementsByTagName("SolicitaDescargaEmitidosResult")[0];
             if (element is null)
             {
                 throw new InvalidResponseContentException("Element SolicitaDescargaEmitidosResult is missing in response.",

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Services/SolicitudDescargaFolioService.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Services/SolicitudDescargaFolioService.cs
@@ -85,7 +85,7 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Services
             XmlDocument xmlDocument = new();
             xmlDocument.LoadXml(soapRequestResult.ResponseContent);
 
-            XmlNode element = xmlDocument.GetElementsByTagName("SolicitaDescargaFolioResult")[0];
+            XmlNode? element = xmlDocument.GetElementsByTagName("SolicitaDescargaFolioResult")[0];
             if (element is null)
             {
                 throw new InvalidResponseContentException("Element SolicitaDescargaFolioResult is missing in response.",

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Services/SolicitudDescargaRecibidosService.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Services/SolicitudDescargaRecibidosService.cs
@@ -122,7 +122,7 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Services
             XmlDocument xmlDocument = new();
             xmlDocument.LoadXml(soapRequestResult.ResponseContent);
 
-            XmlNode element = xmlDocument.GetElementsByTagName("SolicitaDescargaRecibidosResult")[0];
+            XmlNode? element = xmlDocument.GetElementsByTagName("SolicitaDescargaRecibidosResult")[0];
             if (element is null)
             {
                 throw new InvalidResponseContentException("Element SolicitaDescargaRecibidosResult is missing in response.",

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Services/VerificacionService.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Services/VerificacionService.cs
@@ -82,7 +82,7 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Services
             XmlDocument xmlDocument = new();
             xmlDocument.LoadXml(soapRequestResult.ResponseContent);
 
-            XmlNode verificaSolicitudDescargaResultElement = xmlDocument.GetElementsByTagName("VerificaSolicitudDescargaResult")[0];
+            XmlNode? verificaSolicitudDescargaResultElement = xmlDocument.GetElementsByTagName("VerificaSolicitudDescargaResult")[0];
             if (verificaSolicitudDescargaResultElement is null)
             {
                 throw new InvalidResponseContentException("Element VerificaSolicitudDescargaResult is missing in response.",


### PR DESCRIPTION
#### PR Classification
Code cleanup and enhancement of nullability handling.

#### PR Summary
This pull request refines the codebase by enforcing stricter nullability rules and improving type safety across various service classes. Key changes include:  
- `Program.cs`: Changed `AutenticacionRequest`, `SolicitudDescargaRecibidosResult`, and `VerificacionRequest` from nullable to non-nullable types.  
- `SignedXmlHelper.cs`: Updated `GetIdElement` method to return a nullable `XmlElement`.  
- `AutenticacionService.cs`, `DescargaService.cs`, `VerificacionService.cs`: Changed XML node retrieval to nullable types to prevent null reference exceptions.  
- `DescargaMasiva.csproj`: Enabled nullable reference types for the project.  
- Request classes: Assigned default values to certain properties to ensure defined states.  
