### PR TITLE
Convert models to record type

### DIFF
--- a/samples/ConsoleDemo/Program.cs
+++ b/samples/ConsoleDemo/Program.cs
@@ -63,14 +63,8 @@ logger.LogInformation("Buscando el servicio de solicitud de descarga en el conte
 ISolicitudDescargaRecibidosService solicitudService = host.Services.GetRequiredService<ISolicitudDescargaRecibidosService>();
 
 logger.LogInformation("Creando solicitud de solicitud de descarga.");
-SolicitudDescargaRecibidosRequest solicitudPorRangoFecha = new()
-{
-    AccessToken = autenticacionResult.AccessToken,
-    FechaInicial = fechaInicio,
-    FechaFinal = fechaFin,
-    RfcReceptor = rfcReceptor,
-    TipoSolicitud = tipoSolicitud
-};
+SolicitudDescargaRecibidosRequest solicitudPorRangoFecha =
+    new(autenticacionResult.AccessToken, fechaInicio, fechaFin, rfcReceptor, tipoSolicitud);
 
 logger.LogInformation("Enviando solicitud de solicitud de descarga.");
 SolicitudDescargaRecibidosResult solicitudResult =

--- a/samples/ConsoleDemo/Program.cs
+++ b/samples/ConsoleDemo/Program.cs
@@ -123,7 +123,7 @@ IDescargaService descargarSolicitudService = host.Services.GetRequiredService<ID
 foreach (string idsPaquete in verificacionResult.PackageIds)
 {
     logger.LogInformation("Creando solicitud de descarga.");
-    DescargaRequest descargaRequest = DescargaRequest.CreateInstance(idsPaquete, rfcSolicitante, autenticacionResult.AccessToken);
+    DescargaRequest descargaRequest = new(idsPaquete, rfcSolicitante, autenticacionResult.AccessToken);
 
     logger.LogInformation("Enviando solicitud de descarga.");
     DescargaResult descargaResult = await descargarSolicitudService.SendSoapRequestAsync(descargaRequest,

--- a/samples/ConsoleDemo/Program.cs
+++ b/samples/ConsoleDemo/Program.cs
@@ -130,7 +130,7 @@ IDescargaService descargarSolicitudService = host.Services.GetRequiredService<ID
 foreach (string idsPaquete in verificacionResult.PackageIds)
 {
     logger.LogInformation("Creando solicitud de descarga.");
-    DescargaRequest descargaRequest = DescargaRequest.CreateInstace(idsPaquete, rfcSolicitante, autenticacionResult.AccessToken);
+    DescargaRequest descargaRequest = DescargaRequest.CreateInstance(idsPaquete, rfcSolicitante, autenticacionResult.AccessToken);
 
     logger.LogInformation("Enviando solicitud de descarga.");
     DescargaResult descargaResult = await descargarSolicitudService.SendSoapRequestAsync(descargaRequest,

--- a/samples/ConsoleDemo/Program.cs
+++ b/samples/ConsoleDemo/Program.cs
@@ -84,8 +84,7 @@ logger.LogInformation("Buscando el servicio de verificacion en el contenedor de 
 IVerificacionService verificaSolicitudService = host.Services.GetRequiredService<IVerificacionService>();
 
 logger.LogInformation("Creando solicitud de verificacion.");
-VerificacionRequest verificacionRequest =
-    VerificacionRequest.CreateInstance(solicitudResult.IdSolicitud, rfcSolicitante, autenticacionResult.AccessToken);
+VerificacionRequest verificacionRequest = new(solicitudResult.IdSolicitud, rfcSolicitante, autenticacionResult.AccessToken);
 
 logger.LogInformation("Enviando solicitud de verificacion.");
 VerificacionResult verificacionResult = await verificaSolicitudService.SendSoapRequestAsync(verificacionRequest,

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/AccessToken.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/AccessToken.cs
@@ -21,11 +21,6 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
         /// </summary>
         public string HttpAuthorizationHeader => SoapRequestHelper.CreateHttpAuthorizationHeaderFromToken(Value);
 
-        public static AccessToken CreateInstance(string token)
-        {
-            return new AccessToken(token);
-        }
-
         public static AccessToken CreateEmpty()
         {
             return new AccessToken(string.Empty);

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/AccessToken.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/AccessToken.cs
@@ -1,24 +1,14 @@
-﻿using System;
-using System.Web;
+﻿using System.Web;
 using ARSoftware.Cfdi.DescargaMasiva.Helpers;
 
 namespace ARSoftware.Cfdi.DescargaMasiva.Models
 {
     /// <summary>
-    ///     Token de autorizacion para autenticar peticiones con el web service de descarga masiva de CFDIs del SAT
+    ///     Token de autorizacion para autenticar peticiones con el web service de descarga masiva de CFDIs del SAT.
     /// </summary>
-    public sealed class AccessToken
+    /// <param name="Value">Valor del Token tomado del resultado de la peticion de autenticacion.</param>
+    public record AccessToken(string Value)
     {
-        private AccessToken(string value)
-        {
-            Value = value ?? throw new ArgumentNullException(nameof(value));
-        }
-
-        /// <summary>
-        ///     Valor del Token tomado del resultado de la peticion de autenticacion
-        /// </summary>
-        public string Value { get; }
-
         public bool IsValid => !string.IsNullOrWhiteSpace(Value);
 
         /// <summary>

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/AutenticacionRequest.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/AutenticacionRequest.cs
@@ -15,10 +15,5 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
             DateTime tokenCreationDateUtc = DateTime.UtcNow;
             return new AutenticacionRequest(tokenCreationDateUtc, tokenCreationDateUtc.AddMinutes(5), Guid.NewGuid());
         }
-
-        public static AutenticacionRequest CreateInstance(DateTime tokenCreatedDateUtc, DateTime tokenExpiresDateUtc, Guid uuid)
-        {
-            return new AutenticacionRequest(tokenCreatedDateUtc, tokenExpiresDateUtc, uuid);
-        }
     }
 }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/AutenticacionRequest.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/AutenticacionRequest.cs
@@ -5,30 +5,11 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
     /// <summary>
     ///     Peticion de autenticacion.
     /// </summary>
-    public sealed class AutenticacionRequest
+    /// <param name="TokenCreatedDateUtc">Fecha de cuando el token fue creado en formato UTC.</param>
+    /// <param name="TokenExpiresDateUtc">Fecha de cuando el token expira en formato UTC.</param>
+    /// <param name="Uuid">UUID unico para asociar a la peticion.</param>
+    public record AutenticacionRequest(DateTime TokenCreatedDateUtc, DateTime TokenExpiresDateUtc, Guid Uuid)
     {
-        private AutenticacionRequest(DateTime tokenCreatedDateUtc, DateTime tokenExpiresDateUtc, Guid uuid)
-        {
-            TokenCreatedDateUtc = tokenCreatedDateUtc;
-            TokenExpiresDateUtc = tokenExpiresDateUtc;
-            Uuid = uuid;
-        }
-
-        /// <summary>
-        ///     Fecha de cuando el token fue creado en formato UTC.
-        /// </summary>
-        public DateTime TokenCreatedDateUtc { get; }
-
-        /// <summary>
-        ///     Fecha de cuando el token expira en formato UTC.
-        /// </summary>
-        public DateTime TokenExpiresDateUtc { get; }
-
-        /// <summary>
-        ///     UUID unico para asociar a la peticion.
-        /// </summary>
-        public Guid Uuid { get; }
-
         public static AutenticacionRequest CreateInstance()
         {
             DateTime tokenCreationDateUtc = DateTime.UtcNow;

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/AutenticacionResult.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/AutenticacionResult.cs
@@ -17,15 +17,6 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
         HttpStatusCode HttpStatusCode,
         string ResponseContent)
     {
-        public static AutenticacionResult CreateInstance(AccessToken accessToken,
-            string faultCode,
-            string faultString,
-            HttpStatusCode httpStatusCode,
-            string responseContent)
-        {
-            return new AutenticacionResult(accessToken, faultCode, faultString, httpStatusCode, responseContent);
-        }
-
         public static AutenticacionResult CreateSuccess(AccessToken accessToken, HttpStatusCode httpStatusCode, string responseContent)
         {
             return new AutenticacionResult(accessToken, string.Empty, string.Empty, httpStatusCode, responseContent);

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/AutenticacionResult.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/AutenticacionResult.cs
@@ -10,7 +10,7 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
     /// <param name="FaultString"></param>
     /// <param name="HttpStatusCode">Codigo de estatus de la respuesta HTTP.</param>
     /// <param name="ResponseContent">Contenido del mensage de la respuesta HTTP.</param>
-    public sealed record AutenticacionResult(
+    public record AutenticacionResult(
         AccessToken AccessToken,
         string FaultCode,
         string FaultString,

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/AutenticacionResult.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/AutenticacionResult.cs
@@ -1,50 +1,27 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 
 namespace ARSoftware.Cfdi.DescargaMasiva.Models
 {
     /// <summary>
     ///     Resultado de la peticion de autenticacion.
     /// </summary>
-    public sealed class AutenticacionResult
+    /// <param name="AccessToken">Token de autorizacion para autenticar peticiones con el web service.</param>
+    /// <param name="FaultCode"></param>
+    /// <param name="FaultString"></param>
+    /// <param name="HttpStatusCode">Codigo de estatus de la respuesta HTTP.</param>
+    /// <param name="ResponseContent">Contenido del mensage de la respuesta HTTP.</param>
+    public sealed record AutenticacionResult(
+        AccessToken AccessToken,
+        string FaultCode,
+        string FaultString,
+        HttpStatusCode HttpStatusCode,
+        string ResponseContent)
     {
-        private AutenticacionResult(AccessToken accessToken,
-                                    string faultCode,
-                                    string faultString,
-                                    HttpStatusCode httpStatusCode,
-                                    string responseContent)
-        {
-            AccessToken = accessToken ?? throw new ArgumentNullException(nameof(accessToken));
-            FaultCode = faultCode ?? throw new ArgumentNullException(nameof(faultCode));
-            FaultString = faultString ?? throw new ArgumentNullException(nameof(faultString));
-            HttpStatusCode = httpStatusCode;
-            ResponseContent = responseContent ?? throw new ArgumentNullException(nameof(responseContent));
-        }
-
-        /// <summary>
-        ///     Token de autorizacion para autenticar peticiones con el web service.
-        /// </summary>
-        public AccessToken AccessToken { get; }
-
-        public string FaultCode { get; }
-
-        public string FaultString { get; }
-
-        /// <summary>
-        ///     Codigo de estatus de la respuesta HTTP.
-        /// </summary>
-        public HttpStatusCode HttpStatusCode { get; }
-
-        /// <summary>
-        ///     Contenido del mensage de la respuesta HTTP.
-        /// </summary>
-        public string ResponseContent { get; }
-
         public static AutenticacionResult CreateInstance(AccessToken accessToken,
-                                                         string faultCode,
-                                                         string faultString,
-                                                         HttpStatusCode httpStatusCode,
-                                                         string responseContent)
+            string faultCode,
+            string faultString,
+            HttpStatusCode httpStatusCode,
+            string responseContent)
         {
             return new AutenticacionResult(accessToken, faultCode, faultString, httpStatusCode, responseContent);
         }
@@ -55,9 +32,9 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
         }
 
         public static AutenticacionResult CreateFailure(string faultCode,
-                                                        string faultString,
-                                                        HttpStatusCode httpStatusCode,
-                                                        string responseContent)
+            string faultString,
+            HttpStatusCode httpStatusCode,
+            string responseContent)
         {
             return new AutenticacionResult(AccessToken.CreateEmpty(), faultCode, faultString, httpStatusCode, responseContent);
         }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/DescargaRequest.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/DescargaRequest.cs
@@ -9,11 +9,5 @@
     ///     descarga masiva.
     /// </param>
     /// <param name="AccessToken">Token de autorizacion.</param>
-    public record DescargaRequest(string PackageId, string RequestingRfc, AccessToken AccessToken)
-    {
-        public static DescargaRequest CreateInstance(string packageId, string requestingRfc, AccessToken accessToken)
-        {
-            return new DescargaRequest(packageId, requestingRfc, accessToken);
-        }
-    }
+    public record DescargaRequest(string PackageId, string RequestingRfc, AccessToken AccessToken);
 }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/DescargaRequest.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/DescargaRequest.cs
@@ -1,35 +1,17 @@
-﻿using System;
-
-namespace ARSoftware.Cfdi.DescargaMasiva.Models
+﻿namespace ARSoftware.Cfdi.DescargaMasiva.Models
 {
     /// <summary>
     ///     Peticion de descarga.
     /// </summary>
-    public sealed class DescargaRequest
+    /// <param name="PackageId">IdPaquete - Contiene el identificador del paquete que se desea descargar.</param>
+    /// <param name="RequestingRfc">
+    ///     RfcSolicitante - Contiene el RFC del solicitante que genero la petición de solicitud de
+    ///     descarga masiva.
+    /// </param>
+    /// <param name="AccessToken">Token de autorizacion.</param>
+    public record DescargaRequest(string PackageId, string RequestingRfc, AccessToken AccessToken)
     {
-        private DescargaRequest(string packageId, string requestingRfc, AccessToken accessToken)
-        {
-            PackageId = packageId ?? throw new ArgumentNullException(nameof(packageId));
-            RequestingRfc = requestingRfc ?? throw new ArgumentNullException(nameof(requestingRfc));
-            AccessToken = accessToken ?? throw new ArgumentNullException(nameof(accessToken));
-        }
-
-        /// <summary>
-        ///     IdPaquete - Contiene el identificador del paquete que se desea descargar.
-        /// </summary>
-        public string PackageId { get; }
-
-        /// <summary>
-        ///     RfcSolicitante - Contiene el RFC del solicitante que genero la petición de solicitud de descarga masiva.
-        /// </summary>
-        public string RequestingRfc { get; }
-
-        /// <summary>
-        ///     Token de autorizacion.
-        /// </summary>
-        public AccessToken AccessToken { get; }
-
-        public static DescargaRequest CreateInstace(string packageId, string requestingRfc, AccessToken accessToken)
+        public static DescargaRequest CreateInstance(string packageId, string requestingRfc, AccessToken accessToken)
         {
             return new DescargaRequest(packageId, requestingRfc, accessToken);
         }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/DescargaResult.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/DescargaResult.cs
@@ -17,13 +17,5 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
         HttpStatusCode HttpStatusCode,
         string ResponseContent)
     {
-        public static DescargaResult CreateInstance(string package,
-            string requestStatusCode,
-            string requestStatusMessage,
-            HttpStatusCode httpStatusCode,
-            string responseContent)
-        {
-            return new DescargaResult(package, requestStatusCode, requestStatusMessage, httpStatusCode, responseContent);
-        }
     }
 }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/DescargaResult.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/DescargaResult.cs
@@ -1,56 +1,27 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 
 namespace ARSoftware.Cfdi.DescargaMasiva.Models
 {
     /// <summary>
     ///     Resultado de la peticion de descarga.
     /// </summary>
-    public sealed class DescargaResult
+    /// <param name="Package">Paquete - Representa el paquete que se desea descargar.</param>
+    /// <param name="RequestStatusCode">CodEstatus - Código de estatus de la solicitud.</param>
+    /// <param name="RequestStatusMessage">Mensaje - Pequeña descripción del código estatus.</param>
+    /// <param name="HttpStatusCode">Codigo de estatus de la respuesta HTTP.</param>
+    /// <param name="ResponseContent">Contenido del mensage de la respuesta HTTP.</param>
+    public record DescargaResult(
+        string Package,
+        string RequestStatusCode,
+        string RequestStatusMessage,
+        HttpStatusCode HttpStatusCode,
+        string ResponseContent)
     {
-        private DescargaResult(string package,
-                               string requestStatusCode,
-                               string requestStatusMessage,
-                               HttpStatusCode httpStatusCode,
-                               string responseContent)
-        {
-            RequestStatusCode = requestStatusCode ?? throw new ArgumentNullException(nameof(requestStatusCode));
-            RequestStatusMessage = requestStatusMessage ?? throw new ArgumentNullException(nameof(requestStatusMessage));
-            Package = package ?? throw new ArgumentNullException(nameof(package));
-            HttpStatusCode = httpStatusCode;
-            ResponseContent = responseContent ?? throw new ArgumentNullException(nameof(responseContent));
-        }
-
-        /// <summary>
-        ///     Paquete - Representa el paquete que se desea descargar.
-        /// </summary>
-        public string Package { get; }
-
-        /// <summary>
-        ///     CodEstatus - Código de estatus de la solicitud.
-        /// </summary>
-        public string RequestStatusCode { get; }
-
-        /// <summary>
-        ///     Mensaje - Pequeña descripción del código estatus.
-        /// </summary>
-        public string RequestStatusMessage { get; }
-
-        /// <summary>
-        ///     Codigo de estatus de la respuesta HTTP.
-        /// </summary>
-        public HttpStatusCode HttpStatusCode { get; }
-
-        /// <summary>
-        ///     Contenido del mensage de la respuesta HTTP.
-        /// </summary>
-        public string ResponseContent { get; }
-
         public static DescargaResult CreateInstance(string package,
-                                                    string requestStatusCode,
-                                                    string requestStatusMessage,
-                                                    HttpStatusCode httpStatusCode,
-                                                    string responseContent)
+            string requestStatusCode,
+            string requestStatusMessage,
+            HttpStatusCode httpStatusCode,
+            string responseContent)
         {
             return new DescargaResult(package, requestStatusCode, requestStatusMessage, httpStatusCode, responseContent);
         }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/SoapRequestResult.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/SoapRequestResult.cs
@@ -1,29 +1,14 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 
 namespace ARSoftware.Cfdi.DescargaMasiva.Models
 {
     /// <summary>
-    ///     Resultado de la peticion SOAP
+    ///     Resultado de la peticion SOAP.
     /// </summary>
-    public sealed class SoapRequestResult
+    /// <param name="HttpStatusCode">Codigo de estatus de la respuesta HTTP.</param>
+    /// <param name="ResponseContent">Contenido del mensage de la respuesta HTTP.</param>
+    public record SoapRequestResult(HttpStatusCode HttpStatusCode, string ResponseContent)
     {
-        private SoapRequestResult(HttpStatusCode httpStatusCode, string responseContent)
-        {
-            HttpStatusCode = httpStatusCode;
-            ResponseContent = responseContent ?? throw new ArgumentNullException(nameof(responseContent));
-        }
-
-        /// <summary>
-        ///     Codigo de estatus de la respuesta HTTP.
-        /// </summary>
-        public HttpStatusCode HttpStatusCode { get; }
-
-        /// <summary>
-        ///     Contenido del mensage de la respuesta HTTP.
-        /// </summary>
-        public string ResponseContent { get; }
-
         public static SoapRequestResult CreateInstance(HttpStatusCode httpStatusCode, string responseContent)
         {
             return new SoapRequestResult(httpStatusCode, responseContent);

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/SoapRequestResult.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/SoapRequestResult.cs
@@ -7,11 +7,5 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
     /// </summary>
     /// <param name="HttpStatusCode">Codigo de estatus de la respuesta HTTP.</param>
     /// <param name="ResponseContent">Contenido del mensage de la respuesta HTTP.</param>
-    public record SoapRequestResult(HttpStatusCode HttpStatusCode, string ResponseContent)
-    {
-        public static SoapRequestResult CreateInstance(HttpStatusCode httpStatusCode, string responseContent)
-        {
-            return new SoapRequestResult(httpStatusCode, responseContent);
-        }
-    }
+    public record SoapRequestResult(HttpStatusCode HttpStatusCode, string ResponseContent);
 }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaEmitidosRequest.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaEmitidosRequest.cs
@@ -87,14 +87,5 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
         public bool HasRfcACuentaTerceros => !string.IsNullOrWhiteSpace(RfcACuentaTerceros);
 
         public bool HasRfcSolicitante => !string.IsNullOrWhiteSpace(RfcSolicitante);
-
-        public SolicitudDescargaEmitidosRequest CreateInstance(AccessToken accessToken,
-            DateTime fechaInicial,
-            DateTime fechaFinal,
-            string rfcEmisor,
-            TipoSolicitud tipoSolicitud)
-        {
-            return new SolicitudDescargaEmitidosRequest(accessToken, fechaInicial, fechaFinal, rfcEmisor, tipoSolicitud);
-        }
     }
 }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaEmitidosRequest.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaEmitidosRequest.cs
@@ -7,25 +7,32 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
     /// <summary>
     ///     Peticion de solicitud de descarga de CFDIs emitidos.
     /// </summary>
-    public record SolicitudDescargaEmitidosRequest
+    /// <param name="AccessToken">Token de autorizacion.</param>
+    /// <param name="FechaInicial">
+    ///     Solo se buscarán CFDI, cuya fecha de emisión sea igual o mayor a la fecha inicial indicada en este parámetro.
+    ///     Parámetro obligatorio.
+    /// </param>
+    /// <param name="FechaFinal">
+    ///     Solo se buscarán CFDI, cuya fecha de emisión sea igual o menor a la fecha final indicada en este parámetro.
+    ///     Parámetro obligatorio.
+    /// </param>
+    /// <param name="RfcEmisor">
+    ///     Contiene el RFC del emisor del cual se quiere consultar los CFDIs.
+    ///     Parámetro obligatorio.
+    /// </param>
+    /// <param name="TipoSolicitud">
+    ///     Define el tipo de descarga: Metadata o CFDI. Parámetro Obligatorio.
+    ///     • Metadata
+    ///     • CFDI
+    ///     Parámetro Obligatorio.
+    /// </param>
+    public record SolicitudDescargaEmitidosRequest(
+        AccessToken AccessToken,
+        DateTime FechaInicial,
+        DateTime FechaFinal,
+        string RfcEmisor,
+        TipoSolicitud TipoSolicitud)
     {
-        /// <summary>
-        ///     Token de autorizacion.
-        /// </summary>
-        public required AccessToken AccessToken { get; init; }
-
-        /// <summary>
-        ///     Solo se buscarán CFDI, cuya fecha de emisión sea igual o mayor a la fecha inicial indicada en este parámetro.
-        ///     Parámetro obligatorio.
-        /// </summary>
-        public required DateTime FechaInicial { get; init; }
-
-        /// <summary>
-        ///     Solo se buscarán CFDI, cuya fecha de emisión sea igual o menor a la fecha final indicada en este parámetro.
-        ///     Parámetro obligatorio.
-        /// </summary>
-        public required DateTime FechaFinal { get; init; }
-
         /// <summary>
         ///     Contiene el/los RFC’s receptores de los cuales se quiere consultar los CFDIs.
         ///     Importante: El campo RfcReceptor, únicamente permite la captura de 5 registros como máximo.
@@ -33,25 +40,11 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
         public List<string> RfcReceptores { get; init; } = new();
 
         /// <summary>
-        ///     Contiene el RFC del emisor del cual se quiere consultar los CFDIs.
-        ///     Parámetro obligatorio.
-        /// </summary>
-        public required string RfcEmisor { get; init; }
-
-        /// <summary>
         ///     El RFC Solicitante corresponde al contribuyente que está realizando la solicitud de descarga.
         ///     Este parámetro es opcional, pero en caso de proporcionarse debe coincidir con el RFC Emisor.
         ///     Parámetro Opcional.
         /// </summary>
         public string RfcSolicitante { get; init; } = string.Empty;
-
-        /// <summary>
-        ///     Define el tipo de descarga:
-        ///     • Metadata
-        ///     • CFDI
-        ///     Parámetro Obligatorio.
-        /// </summary>
-        public required TipoSolicitud TipoSolicitud { get; init; }
 
         /// <summary>
         ///     Define el tipo de comprobante:
@@ -94,5 +87,14 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
         public bool HasRfcACuentaTerceros => !string.IsNullOrWhiteSpace(RfcACuentaTerceros);
 
         public bool HasRfcSolicitante => !string.IsNullOrWhiteSpace(RfcSolicitante);
+
+        public SolicitudDescargaEmitidosRequest CreateInstance(AccessToken accessToken,
+            DateTime fechaInicial,
+            DateTime fechaFinal,
+            string rfcEmisor,
+            TipoSolicitud tipoSolicitud)
+        {
+            return new SolicitudDescargaEmitidosRequest(accessToken, fechaInicial, fechaFinal, rfcEmisor, tipoSolicitud);
+        }
     }
 }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaEmitidosResult.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaEmitidosResult.cs
@@ -5,38 +5,20 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
     /// <summary>
     ///     Resultado de la peticion de solicitud de descarga de CFDIs emitidos.
     /// </summary>
-    public record SolicitudDescargaEmitidosResult
-    {
-        /// <summary>
-        ///     IdSolicitud - Contiene el resultado de la petición con el código de respuesta y los UUID de los CFDIs de los cuales
-        ///     se solicitó
-        ///     la descarga, pero se encuentran en espera de una confirmación por parte del receptor.
-        /// </summary>
-        public required string IdSolicitud { get; init; }
-
-        /// <summary>
-        ///     RfcSolicitante - Contiene el RFC que realizo la solicitud.
-        /// </summary>
-        public required string RfcSolicitante { get; init; }
-
-        /// <summary>
-        ///     CodEstatus - Código de estatus de la solicitud.
-        /// </summary>
-        public required string CodEstatus { get; init; }
-
-        /// <summary>
-        ///     Mensaje - Pequeña descripción del código estatus.
-        /// </summary>
-        public required string Mensaje { get; init; }
-
-        /// <summary>
-        ///     Codigo de estatus de la respuesta HTTP.
-        /// </summary>
-        public required HttpStatusCode HttpStatusCode { get; init; }
-
-        /// <summary>
-        ///     Contenido del mensage de la respuesta HTTP.
-        /// </summary>
-        public required string ResponseContent { get; init; }
-    }
+    /// <param name="IdSolicitud">
+    ///     Contiene el resultado de la petición con el código de respuesta y los UUID de los CFDIs de
+    ///     los cuales se solicitó la descarga, pero se encuentran en espera de una confirmación por parte del receptor.
+    /// </param>
+    /// <param name="RfcSolicitante">Contiene el RFC que realizo la solicitud.</param>
+    /// <param name="CodEstatus">Código de estatus de la solicitud.</param>
+    /// <param name="Mensaje">Pequeña descripción del código estatus.</param>
+    /// <param name="HttpStatusCode">Codigo de estatus de la respuesta HTTP.</param>
+    /// <param name="ResponseContent">Contenido del mensage de la respuesta HTTP.</param>
+    public record SolicitudDescargaEmitidosResult(
+        string IdSolicitud,
+        string RfcSolicitante,
+        string CodEstatus,
+        string Mensaje,
+        HttpStatusCode HttpStatusCode,
+        string ResponseContent);
 }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaFolioRequest.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaFolioRequest.cs
@@ -3,24 +3,14 @@
     /// <summary>
     ///     Peticion de solicitud de descarga de un CFDI.
     /// </summary>
-    public record SolicitudDescargaFolioRequest
+    /// <param name="AccessToken">Token de autorizacion.</param>
+    /// <param name="Folio">Folio Fiscal con formato: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX. Parámetro obligatorio.</param>
+    public record SolicitudDescargaFolioRequest(AccessToken AccessToken, string Folio)
     {
-        /// <summary>
-        ///     Token de autorizacion.
-        /// </summary>
-        public required AccessToken AccessToken { get; init; }
-
         /// <summary>
         ///     Contiene el RFC del que está realizando la solicitud de descarga.
         /// </summary>
         public string RfcSolicitante { get; init; } = string.Empty;
-
-        /// <summary>
-        ///     Folio Fiscal con formato:
-        ///     XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-        ///     Parámetro obligatorio.
-        /// </summary>
-        public required string Folio { get; init; }
 
         public bool HasRfcSolicitante => !string.IsNullOrEmpty(RfcSolicitante);
     }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaFolioResult.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaFolioResult.cs
@@ -5,38 +5,21 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
     /// <summary>
     ///     Resultado de la peticion de solicitud de descarga de un CFDI.
     /// </summary>
-    public record SolicitudDescargaFolioResult
-    {
-        /// <summary>
-        ///     IdSolicitud - Contiene el resultado de la petición con el código de respuesta y los UUID de los CFDIs de los cuales
-        ///     se solicitó
-        ///     la descarga, pero se encuentran en espera de una confirmación por parte del receptor.
-        /// </summary>
-        public required string IdSolicitud { get; init; }
-
-        /// <summary>
-        ///     RfcSolicitante - Contiene el RFC que realizo la solicitud.
-        /// </summary>
-        public required string RfcSolicitante { get; init; }
-
-        /// <summary>
-        ///     CodEstatus - Código de estatus de la solicitud.
-        /// </summary>
-        public required string CodEstatus { get; init; }
-
-        /// <summary>
-        ///     Mensaje - Pequeña descripción del código estatus.
-        /// </summary>
-        public required string Mensaje { get; init; }
-
-        /// <summary>
-        ///     Codigo de estatus de la respuesta HTTP.
-        /// </summary>
-        public required HttpStatusCode HttpStatusCode { get; init; }
-
-        /// <summary>
-        ///     Contenido del mensage de la respuesta HTTP.
-        /// </summary>
-        public required string ResponseContent { get; init; }
-    }
+    /// <param name="IdSolicitud">
+    ///     IdSolicitud - Contiene el resultado de la petición con el código de respuesta y los UUID de
+    ///     los CFDIs de los cuales se solicitó la descarga, pero se encuentran en espera de una confirmación por parte del
+    ///     receptor.
+    /// </param>
+    /// <param name="RfcSolicitante">RfcSolicitante - Contiene el RFC que realizo la solicitud.</param>
+    /// <param name="CodEstatus">CodEstatus - Código de estatus de la solicitud.</param>
+    /// <param name="Mensaje">Mensaje - Pequeña descripción del código estatus.</param>
+    /// <param name="HttpStatusCode">Codigo de estatus de la respuesta HTTP.</param>
+    /// <param name="ResponseContent">Contenido del mensage de la respuesta HTTP.</param>
+    public record SolicitudDescargaFolioResult(
+        string IdSolicitud,
+        string RfcSolicitante,
+        string CodEstatus,
+        string Mensaje,
+        HttpStatusCode HttpStatusCode,
+        string ResponseContent);
 }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaRecibidosRequest.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaRecibidosRequest.cs
@@ -6,31 +6,27 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
     /// <summary>
     ///     Peticion de solicitud de descarga de CFDIs recibidos.
     /// </summary>
-    public record SolicitudDescargaRecibidosRequest
+    /// <param name="AccessToken">Token de autorizacion.</param>
+    /// <param name="FechaInicial">
+    ///     Solo se buscarán CFDI, cuya fecha de emisión sea igual o mayor a la fecha inicial indicada
+    ///     en este parámetro. Parámetro obligatorio.
+    /// </param>
+    /// <param name="FechaFinal">
+    ///     Solo se buscarán CFDI, cuya fecha de emisión sea igual o menor a la fecha final indicada en
+    ///     este parámetro. Parámetro obligatorio.
+    /// </param>
+    /// <param name="RfcReceptor">
+    ///     Contiene el RFC Receptor el cual corresponde con el contribuyente del cual se requiere la
+    ///     información. Parámetro obligatorio.
+    /// </param>
+    /// <param name="TipoSolicitud">Define el tipo de descarga: • Metadata • CFDI. Parámetro Obligatorio.</param>
+    public record SolicitudDescargaRecibidosRequest(
+        AccessToken AccessToken,
+        DateTime FechaInicial,
+        DateTime FechaFinal,
+        string RfcReceptor,
+        TipoSolicitud TipoSolicitud)
     {
-        /// <summary>
-        ///     Token de autorizacion.
-        /// </summary>
-        public required AccessToken AccessToken { get; init; }
-
-        /// <summary>
-        ///     Solo se buscarán CFDI, cuya fecha de emisión sea igual o mayor a la fecha inicial indicada en este parámetro.
-        ///     Parámetro obligatorio.
-        /// </summary>
-        public required DateTime FechaInicial { get; init; }
-
-        /// <summary>
-        ///     Solo se buscarán CFDI, cuya fecha de emisión sea igual o menor a la fecha final indicada en este parámetro.
-        ///     Parámetro obligatorio.
-        /// </summary>
-        public required DateTime FechaFinal { get; init; }
-
-        /// <summary>
-        ///     Contiene el RFC Receptor el cual corresponde con el contribuyente del cual se requiere la información.
-        ///     Parámetro obligatorio.
-        /// </summary>
-        public required string RfcReceptor { get; init; }
-
         /// <summary>
         ///     Contiene el RFC del emisor del cual se quiere consultar los CFDIs.
         ///     Parámetro opcional.
@@ -43,14 +39,6 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
         ///     Parámetro Opcional.
         /// </summary>
         public string RfcSolicitante { get; init; } = string.Empty;
-
-        /// <summary>
-        ///     Define el tipo de descarga:
-        ///     • Metadata
-        ///     • CFDI
-        ///     Parámetro Obligatorio.
-        /// </summary>
-        public required TipoSolicitud TipoSolicitud { get; init; }
 
         /// <summary>
         ///     Define el tipo de comprobante:
@@ -87,15 +75,10 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
         public string Complemento { get; init; } = string.Empty;
 
         public bool HasTipoComprobante => TipoComprobante != TipoComprobante.Null;
-
         public bool HasEstadoComprobante => EstadoComprobante != EstadoComprobante.Null;
-
         public bool HasComplemento => !string.IsNullOrWhiteSpace(Complemento);
-
         public bool HasRfcACuentaTerceros => !string.IsNullOrWhiteSpace(RfcACuentaTerceros);
-
         public bool HasRfcSolicitante => !string.IsNullOrWhiteSpace(RfcSolicitante);
-
         public bool HasRfcEmisor => !string.IsNullOrWhiteSpace(RfcEmisor);
     }
 }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaRecibidosResult.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/SolicitudDescargaRecibidosResult.cs
@@ -5,38 +5,21 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
     /// <summary>
     ///     Resultado de la peticion de solicitud de descarga de CFDIs recibidos.
     /// </summary>
-    public record SolicitudDescargaRecibidosResult
-    {
-        /// <summary>
-        ///     IdSolicitud - Contiene el resultado de la petición con el código de respuesta y los UUID de los CFDIs de los cuales
-        ///     se solicitó
-        ///     la descarga, pero se encuentran en espera de una confirmación por parte del receptor.
-        /// </summary>
-        public required string IdSolicitud { get; init; }
-
-        /// <summary>
-        ///     RfcSolicitante - Contiene el RFC que realizo la solicitud.
-        /// </summary>
-        public required string RfcSolicitante { get; init; }
-
-        /// <summary>
-        ///     CodEstatus - Código de estatus de la solicitud.
-        /// </summary>
-        public required string CodEstatus { get; init; }
-
-        /// <summary>
-        ///     Mensaje - Pequeña descripción del código estatus.
-        /// </summary>
-        public required string Mensaje { get; init; }
-
-        /// <summary>
-        ///     Codigo de estatus de la respuesta HTTP.
-        /// </summary>
-        public required HttpStatusCode HttpStatusCode { get; init; }
-
-        /// <summary>
-        ///     Contenido del mensage de la respuesta HTTP.
-        /// </summary>
-        public required string ResponseContent { get; init; }
-    }
+    /// <param name="IdSolicitud">
+    ///     IdSolicitud - Contiene el resultado de la petición con el código de respuesta y los UUID de
+    ///     los CFDIs de los cuales se solicitó la descarga, pero se encuentran en espera de una confirmación por parte del
+    ///     receptor.
+    /// </param>
+    /// <param name="RfcSolicitante">RfcSolicitante - Contiene el RFC que realizo la solicitud.</param>
+    /// <param name="CodEstatus">CodEstatus - Código de estatus de la solicitud.</param>
+    /// <param name="Mensaje">Mensaje - Pequeña descripción del código estatus.</param>
+    /// <param name="HttpStatusCode">Codigo de estatus de la respuesta HTTP.</param>
+    /// <param name="ResponseContent">Contenido del mensage de la respuesta HTTP.</param>
+    public record SolicitudDescargaRecibidosResult(
+        string IdSolicitud,
+        string RfcSolicitante,
+        string CodEstatus,
+        string Mensaje,
+        HttpStatusCode HttpStatusCode,
+        string ResponseContent);
 }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/VerificacionRequest.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/VerificacionRequest.cs
@@ -1,37 +1,13 @@
-﻿using System;
-
-namespace ARSoftware.Cfdi.DescargaMasiva.Models
+﻿namespace ARSoftware.Cfdi.DescargaMasiva.Models
 {
     /// <summary>
     ///     Peticion de verificacion.
     /// </summary>
-    public sealed class VerificacionRequest
-    {
-        private VerificacionRequest(string requestId, string requestingRfc, AccessToken accessToken)
-        {
-            RequestId = requestId ?? throw new ArgumentNullException(nameof(requestId));
-            RequestingRfc = requestingRfc ?? throw new ArgumentNullException(nameof(requestingRfc));
-            AccessToken = accessToken ?? throw new ArgumentNullException(nameof(accessToken));
-        }
-
-        /// <summary>
-        ///     IdSolicitud - Contiene el Identificador de la solicitud que se pretende consultar.
-        /// </summary>
-        public string RequestId { get; }
-
-        /// <summary>
-        ///     RfcSolicitante - Contiene el RFC del solicitante que genero la petición de solicitud de descarga masiva.
-        /// </summary>
-        public string RequestingRfc { get; }
-
-        /// <summary>
-        ///     Token de autorizacion.
-        /// </summary>
-        public AccessToken AccessToken { get; }
-
-        public static VerificacionRequest CreateInstance(string requestId, string requestingRfc, AccessToken accessToken)
-        {
-            return new VerificacionRequest(requestId, requestingRfc, accessToken);
-        }
-    }
+    /// <param name="RequestId">IdSolicitud - Contiene el Identificador de la solicitud que se pretende consultar.</param>
+    /// <param name="RequestingRfc">
+    ///     RfcSolicitante - Contiene el RFC del solicitante que genero la petición de solicitud de
+    ///     descarga masiva.
+    /// </param>
+    /// <param name="AccessToken">Token de autorizacion.</param>
+    public sealed record VerificacionRequest(string RequestId, string RequestingRfc, AccessToken AccessToken);
 }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Models/VerificacionResult.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Models/VerificacionResult.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
 
 namespace ARSoftware.Cfdi.DescargaMasiva.Models
@@ -7,88 +6,35 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Models
     /// <summary>
     ///     Resultado de la peticion de verificacion.
     /// </summary>
-    public sealed class VerificacionResult
-    {
-        private VerificacionResult(List<string> packageIds,
-                                   string downloadRequestStatusNumber,
-                                   string downloadRequestStatusCode,
-                                   string numberOfCfdis,
-                                   string requestStatusCode,
-                                   string requestStatusMessage,
-                                   HttpStatusCode httpStatusCode,
-                                   string responseContent)
-        {
-            RequestStatusCode = requestStatusCode ?? throw new ArgumentNullException(nameof(requestStatusCode));
-            DownloadRequestStatusCode = downloadRequestStatusCode ?? throw new ArgumentNullException(nameof(downloadRequestStatusCode));
-            DownloadRequestStatusNumber =
-                downloadRequestStatusNumber ?? throw new ArgumentNullException(nameof(downloadRequestStatusNumber));
-            NumberOfCfdis = numberOfCfdis ?? throw new ArgumentNullException(nameof(numberOfCfdis));
-            RequestStatusMessage = requestStatusMessage ?? throw new ArgumentNullException(nameof(requestStatusMessage));
-            PackageIds = packageIds ?? throw new ArgumentNullException(nameof(packageIds));
-            HttpStatusCode = httpStatusCode;
-            ResponseContent = responseContent ?? throw new ArgumentNullException(nameof(responseContent));
-        }
-
-        /// <summary>
-        ///     IdsPaquetes - Contiene los identificadores de los paquetes que componen la solicitud de descarga masiva. Solo se
-        ///     devuelve cuando la solicitud posee un estatus de finalizado.
-        /// </summary>
-        public List<string> PackageIds { get; }
-
-        /// <summary>
-        ///     EstadoSolicitud - Contiene el número correspondiente al estado de la solicitud de descarga, Estados de la
-        ///     solicitud: [Aceptada=1, EnProceso=2, Terminada=3, Error=4, Rechazada=5, Vencida=6]
-        /// </summary>
-        public string DownloadRequestStatusNumber { get; }
-
-        /// <summary>
-        ///     CodigoEstadoSolicitud - Contiene el código de estado de la solicitud de descarga, los cuales pueden ser
-        ///     5000,5002,5003,5004 o 5005 para más información revisar la tabla “Códigos Solicitud Descarga Masiva”.
-        /// </summary>
-        public string DownloadRequestStatusCode { get; }
-
-        /// <summary>
-        ///     NumeroCFDIs - Número de CFDIs que conforman la solicitud de descarga consultada.
-        /// </summary>
-        public string NumberOfCfdis { get; }
-
-        /// <summary>
-        ///     CodEstatus - Código de estatus de la petición de verificación.
-        /// </summary>
-        public string RequestStatusCode { get; }
-
-        /// <summary>
-        ///     Mensaje- Pequeña descripción del código estatus correspondiente a la petición de verificación.
-        /// </summary>
-        public string RequestStatusMessage { get; }
-
-        /// <summary>
-        ///     Codigo de estatus de la respuesta HTTP.
-        /// </summary>
-        public HttpStatusCode HttpStatusCode { get; }
-
-        /// <summary>
-        ///     Contenido del mensage de la respuesta HTTP.
-        /// </summary>
-        public string ResponseContent { get; }
-
-        public static VerificacionResult CreateInstance(List<string> packageIds,
-                                                        string downloadRequestStatusNumber,
-                                                        string downloadRequestStatusCode,
-                                                        string numberOfCfdis,
-                                                        string requestStatusCode,
-                                                        string requestStatusMessage,
-                                                        HttpStatusCode httpStatusCode,
-                                                        string responseContent)
-        {
-            return new VerificacionResult(packageIds,
-                downloadRequestStatusNumber,
-                downloadRequestStatusCode,
-                numberOfCfdis,
-                requestStatusCode,
-                requestStatusMessage,
-                httpStatusCode,
-                responseContent);
-        }
-    }
+    /// <param name="PackageIds">
+    ///     IdsPaquetes - Contiene los identificadores de los paquetes que componen la solicitud de
+    ///     descarga masiva. Solo se devuelve cuando la solicitud posee un estatus de finalizado.
+    /// </param>
+    /// <param name="DownloadRequestStatusNumber">
+    ///     EstadoSolicitud - Contiene el número correspondiente al estado de la
+    ///     solicitud de descarga, Estados de la solicitud: [Aceptada=1, EnProceso=2, Terminada=3, Error=4, Rechazada=5,
+    ///     Vencida=6]
+    /// </param>
+    /// <param name="DownloadRequestStatusCode">
+    ///     CodigoEstadoSolicitud - Contiene el código de estado de la solicitud de
+    ///     descarga, los cuales pueden ser 5000,5002,5003,5004 o 5005 para más información revisar la tabla “Códigos Solicitud
+    ///     Descarga Masiva”.
+    /// </param>
+    /// <param name="NumberOfCfdis">NumeroCFDIs - Número de CFDIs que conforman la solicitud de descarga consultada.</param>
+    /// <param name="RequestStatusCode">CodEstatus - Código de estatus de la petición de verificación.</param>
+    /// <param name="RequestStatusMessage">
+    ///     Mensaje- Pequeña descripción del código estatus correspondiente a la petición de
+    ///     verificación.
+    /// </param>
+    /// <param name="HttpStatusCode">Codigo de estatus de la respuesta HTTP.</param>
+    /// <param name="ResponseContent">Contenido del mensage de la respuesta HTTP.</param>
+    public sealed record VerificacionResult(
+        List<string> PackageIds,
+        string DownloadRequestStatusNumber,
+        string DownloadRequestStatusCode,
+        string NumberOfCfdis,
+        string RequestStatusCode,
+        string RequestStatusMessage,
+        HttpStatusCode HttpStatusCode,
+        string ResponseContent);
 }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Services/AutenticacionService.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Services/AutenticacionService.cs
@@ -118,7 +118,7 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Services
             XmlNode? autenticaResultElement = xmlDocument.GetElementsByTagName("AutenticaResult")[0];
             if (autenticaResultElement != null)
             {
-                AccessToken accessToken = AccessToken.CreateInstance(autenticaResultElement.InnerXml);
+                AccessToken accessToken = new(autenticaResultElement.InnerXml);
                 return AutenticacionResult.CreateSuccess(accessToken, soapRequestResult.HttpStatusCode, soapRequestResult.ResponseContent);
             }
 

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Services/DescargaService.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Services/DescargaService.cs
@@ -96,7 +96,7 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Services
             string requestStatusCode = element.Attributes.GetNamedItem("CodEstatus")?.Value ?? string.Empty;
             string requestStatusMessage = element.Attributes.GetNamedItem("Mensaje")?.Value ?? string.Empty;
 
-            return DescargaResult.CreateInstance(package, requestStatusCode, requestStatusMessage, soapRequestResult.HttpStatusCode,
+            return new DescargaResult(package, requestStatusCode, requestStatusMessage, soapRequestResult.HttpStatusCode,
                 soapRequestResult.ResponseContent);
         }
     }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Services/HttpSoapClient.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Services/HttpSoapClient.cs
@@ -20,10 +20,10 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Services
         }
 
         public async Task<SoapRequestResult> SendRequestAsync(string url,
-                                                              string soapAction,
-                                                              AccessToken accessToken,
-                                                              string requestContent,
-                                                              CancellationToken cancellationToken)
+            string soapAction,
+            AccessToken accessToken,
+            string requestContent,
+            CancellationToken cancellationToken)
         {
             if (url is null)
                 throw new ArgumentNullException(nameof(url));
@@ -39,7 +39,7 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Services
 
             _httpClient.DefaultRequestHeaders.Clear();
 
-            var request = new HttpRequestMessage(HttpMethod.Post, new Uri(url));
+            HttpRequestMessage request = new(HttpMethod.Post, new Uri(url));
 
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Text.Xml));
 
@@ -52,7 +52,7 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Services
 
             HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
 
-            return SoapRequestResult.CreateInstance(response.StatusCode, await response.Content.ReadAsStringAsync());
+            return new SoapRequestResult(response.StatusCode, await response.Content.ReadAsStringAsync(cancellationToken));
         }
     }
 }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Services/SolicitudDescargaEmitidosService.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Services/SolicitudDescargaEmitidosService.cs
@@ -149,15 +149,14 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Services
             string requestCodEstatus = element.Attributes.GetNamedItem("CodEstatus")?.Value ?? string.Empty;
             string requestMensaje = element.Attributes.GetNamedItem("Mensaje")?.Value ?? string.Empty;
 
-            return new SolicitudDescargaEmitidosResult
-            {
-                RfcSolicitante = requestRfcSolicitante,
-                IdSolicitud = requestIdSolicitud,
-                CodEstatus = requestCodEstatus,
-                Mensaje = requestMensaje,
-                HttpStatusCode = soapRequestResult.HttpStatusCode,
-                ResponseContent = soapRequestResult.ResponseContent
-            };
+            return new SolicitudDescargaEmitidosResult(
+                requestIdSolicitud,
+                requestRfcSolicitante,
+                requestCodEstatus,
+                requestMensaje,
+                soapRequestResult.HttpStatusCode,
+                soapRequestResult.ResponseContent
+            );
         }
     }
 }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Services/SolicitudDescargaFolioService.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Services/SolicitudDescargaFolioService.cs
@@ -103,15 +103,14 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Services
             string requestCodEstatus = element.Attributes.GetNamedItem("CodEstatus")?.Value ?? string.Empty;
             string requestMensaje = element.Attributes.GetNamedItem("Mensaje")?.Value ?? string.Empty;
 
-            return new SolicitudDescargaFolioResult
-            {
-                IdSolicitud = requestIdSolicitud,
-                RfcSolicitante = requestRfcSolicitante,
-                CodEstatus = requestCodEstatus,
-                Mensaje = requestMensaje,
-                HttpStatusCode = soapRequestResult.HttpStatusCode,
-                ResponseContent = soapRequestResult.ResponseContent
-            };
+            return new SolicitudDescargaFolioResult(
+                requestIdSolicitud,
+                requestRfcSolicitante,
+                requestCodEstatus,
+                requestMensaje,
+                soapRequestResult.HttpStatusCode,
+                soapRequestResult.ResponseContent
+            );
         }
     }
 }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Services/SolicitudDescargaRecibidosService.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Services/SolicitudDescargaRecibidosService.cs
@@ -140,15 +140,14 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Services
             string requestCodEstatus = element.Attributes.GetNamedItem("CodEstatus")?.Value ?? string.Empty;
             string requestMensaje = element.Attributes.GetNamedItem("Mensaje")?.Value ?? string.Empty;
 
-            return new SolicitudDescargaRecibidosResult
-            {
-                RfcSolicitante = requestRfcSolicitante,
-                IdSolicitud = requestIdSolicitud,
-                CodEstatus = requestCodEstatus,
-                Mensaje = requestMensaje,
-                HttpStatusCode = soapRequestResult.HttpStatusCode,
-                ResponseContent = soapRequestResult.ResponseContent
-            };
+            return new SolicitudDescargaRecibidosResult(
+                requestIdSolicitud,
+                requestRfcSolicitante,
+                requestCodEstatus,
+                requestMensaje,
+                soapRequestResult.HttpStatusCode,
+                soapRequestResult.ResponseContent
+            );
         }
     }
 }

--- a/src/ARSoftware.Cfdi.DescargaMasiva/Services/VerificacionService.cs
+++ b/src/ARSoftware.Cfdi.DescargaMasiva/Services/VerificacionService.cs
@@ -115,7 +115,7 @@ namespace ARSoftware.Cfdi.DescargaMasiva.Services
                 }
             }
 
-            return VerificacionResult.CreateInstance(packageIdsList, downloadRequestStatusNumber, downloadRequestStatusCode, numberOfCfdis,
+            return new VerificacionResult(packageIdsList, downloadRequestStatusNumber, downloadRequestStatusCode, numberOfCfdis,
                 requestStatusCode, requestStatusMessage, soapRequestResult.HttpStatusCode, soapRequestResult.ResponseContent);
         }
     }


### PR DESCRIPTION
#### PR Classification
Code cleanup to improve readability and maintainability by refactoring classes to use C# records.

#### PR Summary
This pull request refactors multiple classes to utilize C# records, reducing boilerplate code and enhancing clarity. 
- `Program.cs`: Updated request object constructions to use record syntax for concise initialization.
- `AccessToken.cs`: Converted to a record and removed static factory methods for direct instantiation.
- `AutenticacionRequest.cs`, `AutenticacionResult.cs`, `DescargaRequest.cs`, `DescargaResult.cs`: Classes converted to records with appropriate parameters.
- Service classes (`AutenticacionService.cs`, `DescargaService.cs`, etc.): Updated to align with new record types for instantiation and return types.
- Added comments to clarify the purpose of parameters in the new record definitions.
